### PR TITLE
Implemented random deck selection in place of null decks

### DIFF
--- a/YgoMasterClient/DuelStarter.cs
+++ b/YgoMasterClient/DuelStarter.cs
@@ -646,7 +646,7 @@ namespace YgomGame.Room
                 public IntPtr FieldPart2; public IntPtr Mate1; public IntPtr Mate2; public IntPtr MateBase1; public IntPtr MateBase2;
                 public IntPtr Icon1; public IntPtr Icon2; public IntPtr IconFrame1; public IntPtr IconFrame2;
                 public IntPtr Player1; /*public IntPtr Player2; public IntPtr Player3; public IntPtr Player4;*/
-                public IntPtr BGM;
+                public IntPtr BGM; public IntPtr MustBeValidRandom;
             }
 
             DuelSettings settings;
@@ -910,6 +910,7 @@ namespace YgomGame.Room
                 settings.Type = (int)duelType;
                 settings.RandSeed = (uint)GetButtonValueI32(buttons.Seed, 0);
                 settings.noshuffle = !GetButtonValueBool(buttons.Shuffle);
+                settings.MustBeValidRandom = GetButtonValueBool(buttons.MustBeValidRandom);
                 settings.cpu = GetButtonValueI32(buttons.Cpu, int.MaxValue);
                 DuelCpuParam cpuParam;
                 if (Enum.TryParse<DuelCpuParam>(GetButtonValueString(buttons.CpuFlag), out cpuParam) && cpuParam != DuelCpuParam.None)
@@ -957,6 +958,7 @@ namespace YgomGame.Room
                 SetButtonIndexFromString(buttons.DuelType, ((DuelType)settings.Type).ToString());
                 SetButtonIndexFromString(buttons.Seed, settings.RandSeed == 0 ? null : settings.RandSeed.ToString());
                 SetButtonIndexFromBool(buttons.Shuffle, !settings.noshuffle);
+                SetButtonIndexFromBool(buttons.MustBeValidRandom, settings.MustBeValidRandom);
                 SetButtonIndexFromString(buttons.Cpu, settings.cpu == int.MaxValue ? null : settings.cpu.ToString());
                 SetButtonIndexFromString(buttons.CpuFlag, settings.cpuflag);
                 SetButtonIndexFromString(buttons.Limit, ((DuelLimitedType)settings.Limit).ToString());
@@ -1062,6 +1064,9 @@ namespace YgomGame.Room
                 //AddDeckDetailsButton(infosList, isv, 2);
                 //AddDeckDetailsButton(infosList, isv, 3);
                 buttons.LoadFromFile = AddButtonYesNo(infosList, isv, "Load deck from file", false);
+                buttons.MustBeValidRandom = AddButtonYesNo(infosList, isv, "Random decks must be valid", true);
+                buttons.ClearAllDecks = AddButton(infosList, isv, "Clear selected decks");
+                buttons.OpenDeckEditor = AddButton(infosList, isv, "Open deck editor");
                 AddLabel(infosList, "Settings");
                 buttons.StartingPlayer = AddButton(infosList, isv, "Starting player", new string[] { "Random", "1", "2"/*, "3", "4"*/ });
                 buttons.LifePoints = AddButton(infosList, isv, "Life points", lpStrings);
@@ -1101,9 +1106,6 @@ namespace YgomGame.Room
                 buttons.LoadIncludingDecks = AddButton(infosList, isv, "Load (including decks)");
                 buttons.Load = AddButton(infosList, isv, "Load");
                 buttons.Save = AddButton(infosList, isv, "Save");
-                AddLabel(infosList, "Extra");
-                buttons.OpenDeckEditor = AddButton(infosList, isv, "Open deck editor");
-                buttons.ClearAllDecks = AddButton(infosList, isv, "Clear selected decks");
 
                 if (hasExistingSetting)
                 {
@@ -1113,9 +1115,8 @@ namespace YgomGame.Room
 
             void AddDeckDetailsButton(IL2ListExplicit infosList, IntPtr isv, int deckIndex)
             {
-                // NOTE: Changed from string.Empty to "   " as I think there's a bug with empty strings in IL2String
                 DeckInfo deckInfo = settings.Deck[deckIndex];
-                IntPtr button = AddButton(infosList, isv, "Deck" + (deckIndex + 1), new string[] { "   " });//string.Empty });
+                IntPtr button = AddButton(infosList, isv, "Deck" + (deckIndex + 1), new string[] { "Random Deck" });
                 buttons.Decks[button] = deckInfo;
             }
 
@@ -1281,7 +1282,7 @@ namespace YgomGame.Room
                 {
                     return Path.GetFileName(deck.File);
                 }
-                return "   ";//string.Empty;
+                return "Random Deck";
             }
         }
     }

--- a/YgoMasterServer/Acts/Act_Duel.cs
+++ b/YgoMasterServer/Acts/Act_Duel.cs
@@ -145,6 +145,50 @@ namespace YgoMaster
             return duelSettings;
         }
 
+        DeckInfo GetRandomDeck(GameServerWebRequest request, bool mustBeValid, DeckInfo[] deckArray = null)
+        {
+            if (deckArray != null && deckArray.Length <= 0)
+            {
+                throw new Exception("No valid decks were found.");
+            }   
+            if (deckArray == null)
+            {
+                deckArray = request.Player.Decks.Values.ToArray();
+            }
+            int randIndex = rand.Next(deckArray.Length);
+            DeckInfo newDeck = deckArray[randIndex];
+            List<DeckInfo> updatedDeckList = deckArray.ToList();
+            updatedDeckList.RemoveAt(randIndex);
+            deckArray = updatedDeckList.ToArray();
+            if (mustBeValid && !newDeck.IsValid(request.Player)) 
+            {
+                return GetRandomDeck(request, mustBeValid, deckArray);
+            }
+            else
+            {
+                return newDeck;
+            }
+        }
+
+        void HandleRandomDecks(GameServerWebRequest request, DuelSettings duelSettings)
+        {
+            for (int i = 0; i < duelSettings.Deck.Length; i++)
+            {
+                if (duelSettings.Deck[i].IsEmpty())
+                {
+                    try
+                    {
+                        duelSettings.Deck[i] = GetRandomDeck(request, duelSettings.MustBeValidRandom);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.Error.WriteLine(e.Message);
+                        break;
+                    }
+                }
+            }
+        }
+
         void Act_DuelBegin(GameServerWebRequest request)
         {
             //request.StringResponse = @"{""code"":0,""res"":[[10,{""Duel"":{""IsCustomDuel"":true,""OpponentType"":2,""OpponentPartnerType"":0,""RandSeed"":2081258956,""FirstPlayer"":1,""noshuffle"":false,""tag"":false,""dlginfo"":false,""MyID"":0,""MyType"":0,""Type"":0,""MyPartnerType"":1,""PlayableTagPartner"":0,""regulation_id"":0,""duel_start_timestamp"":0,""surrender"":true,""Limit"":0,""GameMode"":0,""cpu"":100,""cpuflag"":null,""LeftTimeMax"":0,""TurnTimeMax"":0,""TotalTimeMax"":0,""Auto"":-1,""rec"":false,""recf"":false,""did"":0,""duel"":null,""is_pvp"":false,""chapter"":0,""bgms"":[],""Deck"":[{""name"":""new ydk"",""ct"":0,""et"":1645640915,""accessory"":{""box"":1080001,""sleeve"":1070001,""field"":1090001,""object"":1100001,""av_base"":0},""pick_cards"":{""ids"":{""1"":0,""2"":0,""3"":0},""r"":{""1"":1,""2"":1,""3"":1}},""Main"":{""CardIds"":[4007,4007,4007,4711,4711,9455,9455,9455,9063,9229,9229,11308,11308,14259,14587,14911,9190,9190,9190,6949,6949,12901,4844,4844,4844,5328,6432,7187,7381,14304,14304,14304,16405,16405,9066,9066,9066,13619,13619,15299,15299],""Rare"":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]},""Extra"":{""CardIds"":[11313,11313,11930,12694,14910,8129,9196,9272,11648,12705,14586,13543,14295,14295,14052],""Rare"":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]},""Side"":{""CardIds"":[],""Rare"":[]}},{""name"":""241244.ydk"",""ct"":0,""et"":0,""accessory"":{""box"":0,""sleeve"":0,""field"":0,""object"":0,""av_base"":0},""pick_cards"":{""ids"":{""1"":0,""2"":0,""3"":0},""r"":{""1"":1,""2"":1,""3"":1}},""Main"":{""CardIds"":[12950,12950,12950,8933,8933,9455,9455,9455,13670,13670,13670,14829,14829,11851,14876,14876,13680,13672,13673,13676,13674,13677,13677,13677,13675,13675,4343,13679,13679,13671,13671,5537,4895,5328,13631,13631,13447,13447,4817,4817],""Rare"":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]},""Extra"":{""CardIds"":[13763,13763,13763,13668,13669,13669,13669,14947,13508,13600,14132,14133,13089,15032,14937],""Rare"":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]},""Side"":{""CardIds"":[],""Rare"":[]}},{""name"":null,""ct"":0,""et"":0,""accessory"":{""box"":0,""sleeve"":0,""field"":0,""object"":0,""av_base"":0},""pick_cards"":{""ids"":{""1"":0,""2"":0,""3"":0},""r"":{""1"":1,""2"":1,""3"":1}},""Main"":{""CardIds"":[],""Rare"":[]},""Extra"":{""CardIds"":[],""Rare"":[]},""Side"":{""CardIds"":[],""Rare"":[]}},{""name"":null,""ct"":0,""et"":0,""accessory"":{""box"":0,""sleeve"":0,""field"":0,""object"":0,""av_base"":0},""pick_cards"":{""ids"":{""1"":0,""2"":0,""3"":0},""r"":{""1"":1,""2"":1,""3"":1}},""Main"":{""CardIds"":[],""Rare"":[]},""Extra"":{""CardIds"":[],""Rare"":[]},""Side"":{""CardIds"":[],""Rare"":[]}}],""reg"":[0,0,0,0],""level"":[0,0,0,0],""follow_num"":[0,0,0,0],""pcode"":[0,0,0,0],""rank"":[0,0,0,0],""DuelistLv"":[0,0,0,0],""name"":[""Duelist"",null,null,null],""avatar"":[0,0,0,0],""avatar_home"":[0,0,0,0],""icon"":[1100001,1100001,1100001,1100001],""icon_frame"":[1030001,1030001,1030001,1030001],""sleeve"":[1070001,1070001,1070001,1070001],""mat"":[1090001,1090001,1090001,1090001],""duel_object"":[1100001,1100001,1100001,1100001],""wallpaper"":[1130001,1130001,1130001,1130001],""profile_tag"":[[],[],[],[]],""story_deck_id"":[0,0,0,0]}},0,0]],""remove"":[""Duel"",""DuelResult"",""Result""]}";
@@ -161,6 +205,7 @@ namespace YgoMaster
                     duelSettings = new DuelSettings();
                     duelSettings.FromDictionary(duelStarterData);
                     duelSettings.IsCustomDuel = true;
+                    HandleRandomDecks(request, duelSettings);
                     duelSettings.SetRequiredDefaults();
                 }
                 else

--- a/YgoMasterServer/DuelSettings.cs
+++ b/YgoMasterServer/DuelSettings.cs
@@ -24,6 +24,7 @@ namespace YgoMaster
         public int OpponentPartnerType;
 
         // Use the same names as in the packet (using reflection here to reduce the amount of manual work)
+        public bool MustBeValidRandom;
         public uint RandSeed;
         public int FirstPlayer;
         public bool noshuffle;

--- a/YgoMasterServer/Infos/DeckInfo.cs
+++ b/YgoMasterServer/Infos/DeckInfo.cs
@@ -70,6 +70,12 @@ namespace YgoMaster
             }
             return true;
         }
+
+        public bool IsEmpty()
+        {
+            return this.GetAllCards().Count == 0;
+        }
+
 #endif
 
         public List<int> GetAllCards(bool main = true, bool extra = true, bool side = false, bool tray = false)


### PR DESCRIPTION
Starting a game with null decks is not naturally possible now. Instead, the default value is a random deck, which can be configured to be valid or not. 

Still, games can have null decks if the user decides that the random deck must be a valid one but no valid deck is found. A message indicating that no valid decks were found will be logged to the console.

Also took the liberty to move the 'Extras' duel buttons to the 'Decks' label since they were all deck-related and the 'clear selected' button was convenient to go back to a random deck.

Preview of the duel screen with changes:
![image](https://user-images.githubusercontent.com/79263044/188501851-cef11cd3-2283-4560-a6a0-0c4174f905c1.png)
