### PR TITLE
Add deck case support for the acessory shop

### DIFF
--- a/YgoMasterServer/GameServer.State.cs
+++ b/YgoMasterServer/GameServer.State.cs
@@ -1430,6 +1430,9 @@ namespace YgoMaster
                             case ItemID.Category.WALLPAPER:
                                 info.SubCategory = (int)ShopSubCategoryAccessory.Wallpaper;
                                 break;
+                            case ItemID.Category.DECK_CASE:
+                                info.SubCategory = (int)ShopSubCategoryAccessory.DeckCase;
+                                break;
                             default:
                                 Utils.LogWarning("Unhandled shop accessory type " + itemCategory + " for item id " + info.Id);
                                 return;

--- a/YgoMasterServer/Infos/ShopInfo.cs
+++ b/YgoMasterServer/Infos/ShopInfo.cs
@@ -509,7 +509,8 @@ namespace YgoMaster
         Field,
         Protector,
         Icon,
-        Wallpaper
+        Wallpaper,
+        DeckCase
     }
 
     /// <summary>


### PR DESCRIPTION
Failed to find `YgomGame.Shop.AccessorySubCategory` again, so I checked the **Shop.get_list** response to confirm `"subCategory":6` as the enum value for the deck case "Xyz Black" (`"itemId":1082001`).