### PR TITLE
Corrected a compiler conflict with GameServer.State.cs

### DIFF
--- a/YgoMasterServer/GameServer.State.cs
+++ b/YgoMasterServer/GameServer.State.cs
@@ -1568,7 +1568,7 @@ namespace YgoMaster
                 {
                     continue;
                 }
-                if (ProgressiveCardList && shopItem == Shop.StandardPack && Shop.StandardPack?.SecretType == ShopItemSecretType.Other)
+                if (ProgressiveCardList && shopItem == Shop.StandardPack && Shop.StandardPack != null && Shop.StandardPack.SecretType == ShopItemSecretType.Other)
                 {
                     // Avoid the Master Pack contributing towards the lowest rarity (any missing cards are appended at the end of this function)
                     continue;
@@ -1614,7 +1614,7 @@ namespace YgoMaster
                     result[cardId] = (int)rarity;
                 }
             }
-            if (ProgressiveCardList && player.ShopState.GetAvailability(Shop, Shop.StandardPack) == PlayerShopItemAvailability.Available && Shop.StandardPack?.SecretType == ShopItemSecretType.Other)
+            if (ProgressiveCardList && player.ShopState.GetAvailability(Shop, Shop.StandardPack) == PlayerShopItemAvailability.Available && Shop.StandardPack != null && Shop.StandardPack.SecretType == ShopItemSecretType.Other)
             {
                 // When the Master Pack finally unlocks (which should be the last pack to unlock) we'll want to make all cards visible, even if they aren't featured in any packs
                 foreach (KeyValuePair<int, int> card in CardRare)


### PR DESCRIPTION
Build.bat appears to be using a compiler that's too out of date to parse the "?." syntax, so it was failing to build with the changes that had been made to the card rarity section of GameServer.State.cs. In lieu of altering the build.bat file I've simply replaced the "?." code in this file with equivalent null checks.