### PR TITLE
Fix token extraction from MultiplayerTokenPrefixSecret

### DIFF
--- a/YgoMasterServer/GameServer.cs
+++ b/YgoMasterServer/GameServer.cs
@@ -688,7 +688,7 @@ namespace YgoMaster
                 {
                     return 0;
                 }
-                token = token.Substring(0, MultiplayerTokenPrefixSecret.Length);
+                token = token.Substring(MultiplayerTokenPrefixSecret.Length); // Take the token after the MultiplayerTokenPrefixSecret
                 if (string.IsNullOrEmpty(token))
                 {
                     return 0;


### PR DESCRIPTION
Adjust token substring extraction to correctly take the token after the MultiplayerTokenPrefixSecret.

Now there is ALWAYS error when enabled `MultiplayerTokenPrefixSecret` in `Settings.json` and opening more than 2 clients:
```
[WARNING] Exception when processing message. Exception: System.Exception: Duplicate player code 123456789. Requested token: 'prefix_client_2'. Existing token: 'prefix_client_1'
   at YgoMaster.GameServer.GetOrCreatePlayerFromToken(String token, String ip)
   at YgoMaster.GameServer.Process(HttpListenerContext context)
```
