### PR TITLE
New command line option: InstantDuel (mod support for upcoming fan game, Master Force)

### DIFF
--- a/YgoMasterClient/ClientSettings.cs
+++ b/YgoMasterClient/ClientSettings.cs
@@ -95,8 +95,8 @@ namespace YgoMasterClient
         public static bool DisableSoloVisualNovel;
         public static bool DisableSoloVisualNovelNextButtonSound;
         public static bool SoloRemoveDuelTutorials;
-	public static bool InstantDuel;
-	public static Dictionary<string, object> InstantDuelConfig;
+        public static bool InstantDuel;
+        public static Dictionary<string, object> InstantDuelConfig;
 
         public static string FilePath
         {

--- a/YgoMasterClient/ClientSettings.cs
+++ b/YgoMasterClient/ClientSettings.cs
@@ -95,6 +95,8 @@ namespace YgoMasterClient
         public static bool DisableSoloVisualNovel;
         public static bool DisableSoloVisualNovelNextButtonSound;
         public static bool SoloRemoveDuelTutorials;
+	public static bool InstantDuel;
+	public static Dictionary<string, object> InstantDuelConfig;
 
         public static string FilePath
         {

--- a/YgoMasterClient/DuelStarter.cs
+++ b/YgoMasterClient/DuelStarter.cs
@@ -132,7 +132,7 @@ namespace YgomGame.Solo
 
         static void SelectTurn(IntPtr thisPtr)
         {
-            if (YgomGame.Room.RoomCreateViewController.IsHacked)
+            if (YgomGame.Room.RoomCreateViewController.IsHacked || YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
             {
                 DuelSettings settings = YgomGame.Room.RoomCreateViewController.Settings;
                 if (settings != null)
@@ -208,7 +208,7 @@ namespace YgomSystem.Network
 
         static IntPtr Duel_begin(IntPtr rulePtr)
         {
-            if (YgomGame.Room.RoomCreateViewController.IsHacked)
+            if (YgomGame.Room.RoomCreateViewController.IsHacked || YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
             {
                 Dictionary<string, object> rule = MiniJSON.Json.Deserialize(YgomMiniJSON.Json.Serialize(rulePtr)) as Dictionary<string, object>;
                 if (rule == null)
@@ -264,6 +264,30 @@ namespace YgomSystem.Network
             {
                 param["turn"] = DuelDll.DLL_DuelGetTurnNum() + 1;
                 param["replayData"] = GetReplayDataString(param);
+            }
+            if (ClientSettings.InstantDuel)
+            {
+                // Use Exit Code to pass Duel Result to the Loader
+                if (Convert.ToInt32(param["res"]) == (int)DuelResultType.Win)
+                {
+                    Environment.Exit(2);
+                }
+                else if (Convert.ToInt32(param["res"]) == (int)DuelResultType.Draw)
+                {
+                    Environment.Exit(4);
+                }
+                else if (Convert.ToInt32(param["res"]) == (int)DuelResultType.Lose)
+                {
+                    Environment.Exit(3);
+                }
+                else if (Convert.ToInt32(param["res"]) == (int)DuelResultType.Time)
+                {
+                    Environment.Exit(5);
+                }
+                else
+                {
+                    Environment.Exit(6);
+                }
             }
             paramPtr = YgomMiniJSON.Json.Deserialize(MiniJSON.Json.Serialize(param));
             return hookDuel_end.Original(paramPtr);
@@ -394,7 +418,7 @@ namespace YgomSystem.Network
 
                 YgomGame.Menu.ProfileReplayViewController.OnNetworkComplete(thisPtr, cmd);
 
-                if (YgomGame.Room.RoomCreateViewController.IsHacked)
+                if (YgomGame.Room.RoomCreateViewController.IsHacked || YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
                 {
                     switch (cmd)
                     {
@@ -503,7 +527,7 @@ namespace YgomGame.Duel
 
         static int get_rivalType(IntPtr thisPtr)
         {
-            if (YgomGame.Room.RoomCreateViewController.IsHacked)
+            if (YgomGame.Room.RoomCreateViewController.IsHacked || YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
             {
                 if (YgomGame.Room.RoomCreateViewController.Settings.OpponentType == 1)
                 {
@@ -657,6 +681,7 @@ namespace YgomGame.Room
         static Dictionary<IntPtr, string[]> buttonsActionSheets = new Dictionary<IntPtr, string[]>();
 
         public static bool IsNextInstanceHacked = false;
+        public static bool HasInstantDuelStarted = false;
         public static bool IsHacked
         {
             get
@@ -777,6 +802,61 @@ namespace YgomGame.Room
             {
                 hookCallAPIRoomCreate.Original(thisPtr);
             }
+        }
+
+        public static void InstantDuel()
+        {
+            // This is required because Act_UserHome sets up some data like card rarities
+            Dictionary<string, object> data_entry = new Dictionary<string, object>();
+            YgomSystem.Network.Request.Entry("User.home", MiniJSON.Json.Serialize(data_entry));
+
+            duelSettingsManager.InitDuelSettings();
+            // Force SettingsClone to refresh
+            duelSettingsManager.SettingsClone = null;
+            DuelSettings settings = duelSettingsManager.SettingsClone;
+
+            settings.Deck[0].Clear();
+            settings.Deck[0].File = Utils.GetValue<string>(ClientSettings.InstantDuelConfig, "deck_player");
+            settings.Deck[0].Load();
+            settings.Deck[1].Clear();
+            settings.Deck[1].File = Utils.GetValue<string>(ClientSettings.InstantDuelConfig, "deck_opponent");
+            settings.Deck[1].Load();
+
+            // default cpu settings Konami uses for their Solo Mode
+            settings.cpu = 100;
+            settings.cpuflag = "Light";
+            
+            // the AI plays too passive on the first turn, so we make the player go first
+            settings.FirstPlayer = 0;
+
+            List<int> hnum = Utils.GetIntList(ClientSettings.InstantDuelConfig, "hnum");
+            if (hnum.Count == 2)
+            {
+                settings.hnum[0] = hnum[0];
+                settings.hnum[1] = hnum[1];
+            }
+
+            List<int> life = Utils.GetIntList(ClientSettings.InstantDuelConfig, "life");
+            if (life.Count == 2)
+            {
+                settings.life[0] = life[0];
+                settings.life[1] = life[1];
+            }
+
+            settings.SharedField = Utils.GetValue<int>(ClientSettings.InstantDuelConfig, "field", 1090001);
+            // call this again so the field is properly set
+            settings.SetRequiredDefaults();
+
+            Dictionary<string, object> data = new Dictionary<string, object>()
+            {
+                { "chapter", ClientSettings.DuelStarterLiveChapterId }
+            };
+            if (!Program.IsLive)
+            {
+                data["customduel"] = true;
+            }
+            
+            YgomSystem.Network.Request.Entry("Solo.start", MiniJSON.Json.Serialize(data));
         }
 
         static IntPtr AddLabel(IL2ListExplicit infosList, string label)
@@ -932,6 +1012,14 @@ namespace YgomGame.Room
                 set
                 {
                     settingsClone = value;
+                }
+            }
+
+            public void InitDuelSettings()
+            {
+                if (settings == null)
+                {
+                    settings = new DuelSettings();
                 }
             }
 
@@ -1960,11 +2048,20 @@ namespace YgomSystem.UI
 
         public static IntPtr LoadViewControllerPrefab(IntPtr thisPtr, IntPtr prefabpathPtr)
         {
-            /*if (prefabpathPtr != IntPtr.Zero)
+            if (prefabpathPtr != IntPtr.Zero)
             {
                 string prefabpath = new IL2String(prefabpathPtr).ToString();
-                Console.WriteLine("vc: " + prefabpath);
-            }*/
+                //Console.WriteLine("Load vc: " + prefabpath);
+                if (prefabpath == "Title/Title" && ClientSettings.InstantDuel && !YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
+                {
+                    // Without this asset a Fusion Summon freezes the duel
+                    AssetHelper.Load("Duel/ScriptableObject/FusionEffectSetting", IntPtr.Zero);
+                    // Start the Instant Duel straight from the Title Screen
+                    YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted = true;
+                    YgomGame.Room.RoomCreateViewController.InstantDuel();
+                }
+
+            }
             return hookLoadViewControllerPrefab.Original.Invoke(thisPtr, prefabpathPtr);
         }
 

--- a/YgoMasterClient/DuelStarter.cs
+++ b/YgoMasterClient/DuelStarter.cs
@@ -806,10 +806,6 @@ namespace YgomGame.Room
 
         public static void InstantDuel()
         {
-            // This is required because Act_UserHome sets up some data like card rarities
-            Dictionary<string, object> data_entry = new Dictionary<string, object>();
-            YgomSystem.Network.Request.Entry("User.home", MiniJSON.Json.Serialize(data_entry));
-
             duelSettingsManager.InitDuelSettings();
             // Force SettingsClone to refresh
             duelSettingsManager.SettingsClone = null;
@@ -846,6 +842,9 @@ namespace YgomGame.Room
             settings.SharedField = Utils.GetValue<int>(ClientSettings.InstantDuelConfig, "field", 1090001);
             // call this again so the field is properly set
             settings.SetRequiredDefaults();
+
+            // randomize BGM
+            settings.SetRandomBgm();
 
             Dictionary<string, object> data = new Dictionary<string, object>()
             {
@@ -2052,13 +2051,17 @@ namespace YgomSystem.UI
             {
                 string prefabpath = new IL2String(prefabpathPtr).ToString();
                 //Console.WriteLine("Load vc: " + prefabpath);
-                if (prefabpath == "Title/Title" && ClientSettings.InstantDuel && !YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
+                if (prefabpath == "Title/Title" && ClientSettings.InstantDuel)
+                {  
+                    // First we skip the Title Screen
+                    prefabpathPtr = new IL2String("GameEntry/V1/GameEntryV1").ptr;
+                }else if (prefabpath == "Home/Home" && ClientSettings.InstantDuel && !YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted)
                 {
-                    // Without this asset a Fusion Summon freezes the duel
-                    AssetHelper.Load("Duel/ScriptableObject/FusionEffectSetting", IntPtr.Zero);
-                    // Start the Instant Duel straight from the Title Screen
+                    // Start the Instant Duel once the Home Screen is about to load
+                    // Any earlier would cause issues like BGM not playing, Effects missing
                     YgomGame.Room.RoomCreateViewController.HasInstantDuelStarted = true;
                     YgomGame.Room.RoomCreateViewController.InstantDuel();
+                    prefabpathPtr = new IL2String("Solo/SoloStartProduction").ptr;
                 }
 
             }

--- a/YgoMasterClient/DuelStarter.cs
+++ b/YgoMasterClient/DuelStarter.cs
@@ -839,8 +839,10 @@ namespace YgomGame.Room
                 settings.life[1] = life[1];
             }
 
+            settings.duel_object[0] = 0;
+            settings.duel_object[1] = 0;
             settings.SharedField = Utils.GetValue<int>(ClientSettings.InstantDuelConfig, "field", 1090001);
-            // call this again so the field is properly set
+            // call this again so the field and field objects are set according to SharedField
             settings.SetRequiredDefaults();
 
             // randomize BGM

--- a/YgoMasterClient/DuelStarter.cs
+++ b/YgoMasterClient/DuelStarter.cs
@@ -846,6 +846,10 @@ namespace YgomGame.Room
             // randomize BGM
             settings.SetRandomBgm();
 
+            // set AI icon & name
+            settings.icon[1] = 1010039; // Another Duelist
+            settings.name[1] = Utils.GetValue<string>(ClientSettings.InstantDuelConfig, "name_opponent", "CPU");
+
             Dictionary<string, object> data = new Dictionary<string, object>()
             {
                 { "chapter", ClientSettings.DuelStarterLiveChapterId }

--- a/YgoMasterClient/GameLauncher.cs
+++ b/YgoMasterClient/GameLauncher.cs
@@ -33,6 +33,19 @@ namespace YgoMasterClient
 
     class GameLauncher
     {
+	// InstantDuel: We're going to wait for the 
+	// Client's Exit Code to report the result back
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+        // Constants
+        const UInt32 INFINITE = 0xFFFFFFFF;
+        const UInt32 WAIT_FAILED = 0xFFFFFFFF;
+
         public const string TargetProcessName = "masterduel.exe";
         public const string LoaderDll = "YgoMasterLoader.dll";
 
@@ -145,6 +158,22 @@ namespace YgoMasterClient
                 {
                     System.Windows.Forms.MessageBox.Show("DetourCreateProcessWithDll failed " + Marshal.GetLastWin32Error());
                     return false;
+                }
+                if (ClientSettings.InstantDuel) { 
+                    // Wait for the Client to Exit
+                    UInt32 result = WaitForSingleObject(pi.hProcess, INFINITE);
+                    if (result != WAIT_FAILED)
+                    {
+                        uint exitCode = 0;
+                        // The Client communicates the Duel Result via its Exit Code
+                        if (GetExitCodeProcess(pi.hProcess, out exitCode))
+                        {
+                            // Write the result to standard output for inter-process communication
+                            Console.WriteLine("YGO_MASTER_CLIENT_EXIT_CODE:" + exitCode);
+                        }
+                    }
+                    CloseHandle(pi.hProcess);
+                    CloseHandle(pi.hThread);
                 }
                 return true;
             }

--- a/YgoMasterClient/GameLauncher.cs
+++ b/YgoMasterClient/GameLauncher.cs
@@ -33,8 +33,8 @@ namespace YgoMasterClient
 
     class GameLauncher
     {
-	// InstantDuel: We're going to wait for the 
-	// Client's Exit Code to report the result back
+        // InstantDuel: We're going to wait for the 
+        // Client's Exit Code to report the result back
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
 

--- a/YgoMasterClient/Program.cs
+++ b/YgoMasterClient/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.IO;
 using System.Threading;
 using System.Reflection;
@@ -40,6 +41,13 @@ namespace YgoMasterClient
                 if (!string.IsNullOrEmpty(ClientSettings.MultiplayerToken))
                 {
                     isMultiplayerClient = true;
+                }
+                // We need to check for this option now
+                // If present, we make the GameLauncher wait for the Client to Exit
+                // and write the result to standard output for inter-process communication
+                if ((args.Length > 0 && args[0].ToLower() == "instantduel"))
+                {
+                    ClientSettings.InstantDuel = true;
                 }
             }
             catch
@@ -130,7 +138,7 @@ namespace YgoMasterClient
                         ClientSettings.LaunchMode = GameLauncherMode.Detours;
                         break;
                 }
-                success = GameLauncher.Launch(ClientSettings.LaunchMode);
+                success = GameLauncher.Launch(ClientSettings.LaunchMode, args);
             }
             if (!success)
             {
@@ -177,6 +185,25 @@ namespace YgoMasterClient
                 if (ClientSettings.ShowConsole)
                 {
                     ConsoleHelper.ShowConsole();
+                }
+
+                ClientSettings.InstantDuel = false;
+                if (arg != null)
+                {
+                    // parse command line arguments
+                    var matches = Regex.Matches(arg, @"[\""].+?[\""]|[^ ]+");
+                    string[] args = new string[matches.Count];
+
+                    for (int i = 0; i < matches.Count; i++)
+                    {
+                        args[i] = matches[i].Value.Trim('"');
+                    }
+
+                    if (args.Length>=2 && args[0].ToLower() == "instantduel")
+                    {
+                        ClientSettings.InstantDuel = true;
+                        ClientSettings.InstantDuelConfig = MiniJSON.Json.DeserializeStripped(args[1]) as Dictionary<string, object>;
+                    }
                 }
 
                 string pluginsDir = Path.Combine(CurrentDir, "Plugins");

--- a/YgoMasterClient/Program.cs
+++ b/YgoMasterClient/Program.cs
@@ -188,10 +188,11 @@ namespace YgoMasterClient
                 }
 
                 ClientSettings.InstantDuel = false;
-                if (arg != null)
+                string arg_cl = Environment.CommandLine;
+                if (arg_cl != null)
                 {
                     // parse command line arguments
-                    var matches = Regex.Matches(arg, @"[\""].+?[\""]|[^ ]+");
+                    var matches = Regex.Matches(arg_cl, @"[\""].+?[\""]|[^ ]+");
                     string[] args = new string[matches.Count];
 
                     for (int i = 0; i < matches.Count; i++)

--- a/YgoMasterLoader/YgoMasterLoader.cpp
+++ b/YgoMasterLoader/YgoMasterLoader.cpp
@@ -166,7 +166,7 @@ HRESULT LoadDotNetImpl()
     {
         return 0x1333337;
     }
-    result = runtimeHost->ExecuteInDefaultAppDomain(binaryPath, L"YgoMasterClient.Program", L"DllMain", runningLive ? L"live" : NULL, NULL);
+    result = runtimeHost->ExecuteInDefaultAppDomain(binaryPath, L"YgoMasterClient.Program", L"DllMain", runningLive ? L"live" : GetCommandLineW(), NULL);
     return result;
 }
 

--- a/YgoMasterLoader/YgoMasterLoader.cpp
+++ b/YgoMasterLoader/YgoMasterLoader.cpp
@@ -166,7 +166,7 @@ HRESULT LoadDotNetImpl()
     {
         return 0x1333337;
     }
-    result = runtimeHost->ExecuteInDefaultAppDomain(binaryPath, L"YgoMasterClient.Program", L"DllMain", runningLive ? L"live" : GetCommandLineW(), NULL);
+    result = runtimeHost->ExecuteInDefaultAppDomain(binaryPath, L"YgoMasterClient.Program", L"DllMain", runningLive ? L"live" : NULL, NULL);
     return result;
 }
 


### PR DESCRIPTION
As the title says, these changes add a new command line option and the necessary functions to support the game/mod I've been working on these past 4 months (which I'm tentatively calling 'Master Force').

When GameLauncher launches YgoMasterClient, it now waits for the latter to exit. The Exit Code of YgoMasterClient is used to communicate the Duel Result. GameLauncher writes the result to standard output (which I can read from my game) and then exits itself.
Additionally, YgoMasterClient now parses the command line arguments and checks for the new option 'InstantDuel' followed by a duel config as a JSON string. When the ViewController for the Title Screen is loaded, the Client instantly jumps into a duel with the aforementioned config. Currently my game passes the deck paths, starting LP, hand sizes and duel fields for player and opponent using this config string.

The game is now complete and works fine in conjunction with YgoMaster, with the only remaining issue being that the BGM is unfortunately not working when the duel is launched this way.
I am glad to make changes or refactor the code if necessary. If these changes are too intrusive for the main repository, I am open to maintaining a separate fork.
I can also provide a pre-release version of the game for testing purposes, otherwise I'll be publishing the game after these changes are approved.